### PR TITLE
Use explicit path to phpcs.

### DIFF
--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -14,7 +14,7 @@ fi
 # Run PHP CodeSniffer
 echo "Running PHP CodeSniffer..."
 
-git diff --name-only --cached | xargs phpcs $standard
+git diff --name-only --cached | xargs vendor/bin/phpcs $standard
 if [ $? != 0 ]
 then
 	echo "Please fix coding standards errors before committing"


### PR DESCRIPTION
Makes sure that we use the local install of phpcs, which should also
ensure that we use the local installed copy of the standards.

Fixes #11.
