### PR TITLE
Fix Windows Path Issues

### DIFF
--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -3,8 +3,8 @@
 # Copy files for WP Enforcer into the project directory.
 
 readonly VERSION="0.4.0"
-readonly BIN="$(cd "$(dirname "$0")" && pwd -P)"
-readonly DIR="$BIN/$(dirname "$(readlink "$0")")"
+readonly BIN="$(cd "$(composer config --absolute bin-dir)" && pwd -P)"
+readonly DIR="$(cd "$(composer config --absolute vendor-dir)" && pwd -P)/stevegrunwell/wp-enforcer/bin"
 readonly PROJECT="$(pwd)"
 vip=false
 ruleset=false


### PR DESCRIPTION
On Windows (even under MSYS2, which is used by Git), tools like `readlink`
are returing the wrong path and causing the installation routine to fail.
Instead, we can use Composer's native configuration fetcher to figure out
where the bin and vendor directories live.

@TODO Find a way around hard-coding the project name in the `DIR`
variable.

Fixes bugs that went unnoticed in #2.
