### PR TITLE
Feature: Allow define where the actuall vendor folder is

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ If you'd like to require WP Enforcer for all developers on your project, you can
 }
 ```
 
+If you have your vendor directory in a lower level path just add it:
+
+```json
+{
+	"scripts": {
+		"post-install-cmd": [
+			"wp-enforcer <path/to/dir>"
+		],
+		"post-update-cmd": [
+			"wp-enforcer <path/to/dir>"
+		]
+	}
+}
+```
+
 
 ### Writing for WordPress.com VIP
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ If you have your vendor directory in a lower level path just add it:
 }
 ```
 
+Also you can setup a global phpcs instance and standard to use:
+
+```json
+{
+	"scripts": {
+		"post-install-cmd": [
+			"wp-enforcer global WordPress-Core"
+		],
+		"post-update-cmd": [
+			"wp-enforcer global WordPress-Core"
+		]
+	}
+}
+```
+
 
 ### Writing for WordPress.com VIP
 

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -16,7 +16,7 @@ fi
 # Run PHP_CodeSniffer
 echo "Running PHP_CodeSniffer..."
 
-git diff --name-only --cached --diff-filter=ACMRTUXB **/*.php | xargs {phpcs_path} $standard
+git diff --name-only --cached --diff-filter=ACMR | grep \.php | awk '{print}' ORS=' ' | xargs phpcs $standard
 if [ $? != 0 ]
 then
 	echo "Please fix coding standards errors before committing"

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -5,7 +5,7 @@
 # @package WP Enforcer
 
 # Determine if we have a phpcs.xml file
-if [[ "phpcs" -eq "{phpcs_path}" && {phpcs_path} $(phpcs -i | grep {phpcs_standard} | head -c1 | wc -c) -ne 0 ]]; then
+if [[ "phpcs" -eq "{phpcs_path}" && 0 -ne $(phpcs -i | grep {phpcs_standard} | head -c1 | wc -c) ]]; then
 	standard="--standard={phpcs_standard}"
 elif [[ -f ./phpcs.xml ]]; then
 	standard="--standard=./phpcs.xml"

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -5,8 +5,8 @@
 # @package WP Enforcer
 
 # Determine if we have a phpcs.xml file
-if [[ $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
-	standard="--standard=WordPress"
+if [[ "phpcs" -eq "{phpcs_path}" && {phpcs_path} $(phpcs -i | grep {phpcs_standard} | head -c1 | wc -c) -ne 0 ]]; then
+	standard="--standard={phpcs_standard}"
 elif [[ -f ./phpcs.xml ]]; then
 	standard="--standard=./phpcs.xml"
 else
@@ -16,7 +16,7 @@ fi
 # Run PHP_CodeSniffer
 echo "Running PHP_CodeSniffer..."
 
-git diff --name-only --cached --diff-filter=ACMRTUXB | xargs {root}vendor/bin/phpcs $standard
+git diff --name-only --cached --diff-filter=ACMRTUXB | xargs {phpcs_path} $standard
 if [ $? != 0 ]
 then
 	echo "Please fix coding standards errors before committing"

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -5,7 +5,9 @@
 # @package WP Enforcer
 
 # Determine if we have a phpcs.xml file
-if [[ -f ./phpcs.xml ]]; then
+if [[ $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
+	standard="--standard=WordPress"
+elif [[ -f ./phpcs.xml ]]; then
 	standard="--standard=./phpcs.xml"
 else
 	standard=''

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -5,10 +5,10 @@
 # @package WP Enforcer
 
 # Determine if we have a phpcs.xml file
-if [[ "phpcs" -eq "{phpcs_path}" && 0 -ne $(phpcs -i | grep {phpcs_standard} | head -c1 | wc -c) ]]; then
+if [[ "phpcs" -eq "{phpcs_path}" && 0 -lt $(phpcs -i | grep -woe {phpcs_standard} | wc -w) ]]; then
 	standard="--standard={phpcs_standard}"
-elif [[ -f ./phpcs.xml ]]; then
-	standard="--standard=./phpcs.xml"
+elif [[ -f {project}/phpcs.xml ]]; then
+	standard="--standard={project}/phpcs.xml"
 else
 	standard=''
 fi

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -16,7 +16,7 @@ fi
 # Run PHP_CodeSniffer
 echo "Running PHP_CodeSniffer..."
 
-git diff --name-only --cached --diff-filter=ACMRTUXB | xargs {phpcs_path} $standard
+git diff --name-only --cached --diff-filter=ACMRTUXB **/*.php | xargs {phpcs_path} $standard
 if [ $? != 0 ]
 then
 	echo "Please fix coding standards errors before committing"

--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -14,7 +14,7 @@ fi
 # Run PHP_CodeSniffer
 echo "Running PHP_CodeSniffer..."
 
-git diff --name-only --cached --diff-filter=ACMRTUXB | xargs vendor/bin/phpcs $standard
+git diff --name-only --cached --diff-filter=ACMRTUXB | xargs {root}vendor/bin/phpcs $standard
 if [ $? != 0 ]
 then
 	echo "Please fix coding standards errors before committing"

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -23,12 +23,10 @@ error() {
 }
 
 update_root_path() {
-  if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe ${PHPCS_STANDARD} | wc -w) ]]; then
+
+  if [[ "global" -eq ${PHPCS_PATH} ]]; then
     sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
     sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}=g ${PROJECT}/.git/hooks/pre-commit
-  elif [[ "global" -eq ${PHPCS_PATH} ]]; then
-    sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
-    sed -i.bak s={phpcs_standard}=" "=g ${PROJECT}/.git/hooks/pre-commit
   else
     sed -i.bak s={phpcs_path}=${PROJECT}/vendor/bin/phpcs=g ${PROJECT}/.git/hooks/pre-commit
   fi

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -7,7 +7,7 @@ readonly BIN="$(cd "$(dirname "$0")" && pwd -P)"
 readonly DIR="$BIN/$(dirname "$(readlink "$0")")"
 readonly PROJECT="$(git rev-parse --show-toplevel)"
 readonly PHPCS_PATH=$1
-readonly PHPCS_STANDARD=$2
+readonly PHPCS_STANDARD=${2-" "}
 readonly ROOT="${PROJECT}/${PHPCS_PATH}"
 
 vip=false
@@ -23,7 +23,7 @@ error() {
 }
 
 update_root_path() {
-  if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe "${PHPCS_STANDARD}" | wc -w) ]]; then
+  if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe ${PHPCS_STANDARD} | wc -w) ]]; then
     sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
     sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}=g ${PROJECT}/.git/hooks/pre-commit
   elif [[ "global" -eq ${PHPCS_PATH} ]]; then
@@ -138,7 +138,7 @@ fi
 
 # Copy the PHP_CodeSniffer standards file if WordPress standard is not available
 #
-if [[ "global" -eq ${PHPCS_PATH} && 0 -ne $(phpcs -i | grep ${PHPCS_STANDARD} | head -c1 | wc -c) ]]; then
+if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe ${PHPCS_STANDARD} | wc -w) ]]; then
   echo "WordPress standard is installed as global"
 elif [[ ! -f "$PROJECT"/phpcs.xml && "$ruleset" = false ]]; then
   if [ "$vip" = false ]; then

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -6,7 +6,9 @@ readonly VERSION="0.5.0"
 readonly BIN="$(cd "$(dirname "$0")" && pwd -P)"
 readonly DIR="$BIN/$(dirname "$(readlink "$0")")"
 readonly PROJECT="$(git rev-parse --show-toplevel)"
-readonly ROOT="${PROJECT}/$1"
+readonly PHPCS_PATH=$1
+readonly PHPCS_STANDARD=$2
+readonly ROOT="${PROJECT}/${PHPCS_PATH}"
 
 vip=false
 ruleset=false
@@ -21,7 +23,12 @@ error() {
 }
 
 update_root_path() {
-  sed -i.bak s={root}=${ROOT}/=g ${PROJECT}/.git/hooks/pre-commit
+  if [[ "global" -eq ${PHPCS_PATH} && $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
+    sed -i.bak s={phpcs_path}=${PHPCS_PATH}/=g ${PROJECT}/.git/hooks/pre-commit
+    sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}/=g ${PROJECT}/.git/hooks/pre-commit
+  else
+    sed -i.bak s={phpcs_path}=${PROJECT}/vendor/bin/phpcs=g ${PROJECT}/.git/hooks/pre-commit
+  fi
 }
 
 # Define command-line options here.
@@ -126,7 +133,7 @@ fi
 
 # Copy the PHP_CodeSniffer standards file if WordPress standard is not available
 #
-if [[ $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
+if [[ "global" -eq ${PHPCS_PATH} && 0 -ne $(phpcs -i | grep ${PHPCS_STANDARD} | head -c1 | wc -c) ]]; then
   echo "WordPress standard is installed as global"
 elif [[ ! -f "$PROJECT"/phpcs.xml && "$ruleset" = false ]]; then
   if [ "$vip" = false ]; then

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -24,8 +24,8 @@ error() {
 
 update_root_path() {
   if [[ "global" -eq ${PHPCS_PATH} && $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
-    sed -i.bak s={phpcs_path}=${PHPCS_PATH}/=g ${PROJECT}/.git/hooks/pre-commit
-    sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}/=g ${PROJECT}/.git/hooks/pre-commit
+    sed -i.bak s={phpcs_path}=${PHPCS_PATH}=g ${PROJECT}/.git/hooks/pre-commit
+    sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}=g ${PROJECT}/.git/hooks/pre-commit
   else
     sed -i.bak s={phpcs_path}=${PROJECT}/vendor/bin/phpcs=g ${PROJECT}/.git/hooks/pre-commit
   fi

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -21,7 +21,7 @@ error() {
 }
 
 update_root_path() {
-  sed -i.bak s={root}=${ROOT}=g ${DIR}/hooks/pre-commit
+  sed -i.bak s={root}=${ROOT}=g ${PROJECT}/.git/hooks/pre-commit
 }
 
 # Define command-line options here.

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -26,6 +26,8 @@ update_root_path() {
   if [[ "global" -eq ${PHPCS_PATH} && $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
     sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
     sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}=g ${PROJECT}/.git/hooks/pre-commit
+  elif [[ "global" -eq ${PHPCS_PATH} ]]; then
+    sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
   else
     sed -i.bak s={phpcs_path}=${PROJECT}/vendor/bin/phpcs=g ${PROJECT}/.git/hooks/pre-commit
   fi

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -6,6 +6,8 @@ readonly VERSION="0.5.0"
 readonly BIN="$(cd "$(dirname "$0")" && pwd -P)"
 readonly DIR="$BIN/$(dirname "$(readlink "$0")")"
 readonly PROJECT="$(pwd)"
+readonly ROOT="$DIR/$1"
+
 vip=false
 ruleset=false
 
@@ -16,6 +18,10 @@ error() {
   echo "You may re-run this setup at any time by running $DIR/wp-enforcer"
   echo
   exit 1;
+}
+
+update_root_path() {
+  sed -i.bak /{root}/"$ROOT"/g "$DIR"/hooks/pre-commit
 }
 
 # Define command-line options here.
@@ -107,6 +113,7 @@ if [[ -f "$PROJECT"/.git/hooks/pre-commit ]]; then
     echo "A pre-commit hook already exists in $PROJECT/.git/hooks/pre-commit."
     if confirm "Overwrite the existing file?"; then
       copy_hook "pre-commit"
+      update_root_path
     fi
   else
     echo "pre-commit hook already exists, skipping"
@@ -114,6 +121,7 @@ if [[ -f "$PROJECT"/.git/hooks/pre-commit ]]; then
 
 else
   copy_hook "pre-commit"
+  update_root_path
 fi
 
 # Copy the PHP_CodeSniffer standards file

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -124,8 +124,11 @@ else
   update_root_path
 fi
 
-# Copy the PHP_CodeSniffer standards file
-if [[ ! -f "$PROJECT"/phpcs.xml && "$ruleset" = false ]]; then
+# Copy the PHP_CodeSniffer standards file if WordPress standard is not available
+#
+if [[ $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
+  echo "WordPress standard is installed as global"
+elif [[ ! -f "$PROJECT"/phpcs.xml && "$ruleset" = false ]]; then
   if [ "$vip" = false ]; then
     sample_file_name="phpcs.xml.sample"
   else

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -24,7 +24,7 @@ error() {
 
 update_root_path() {
   if [[ "global" -eq ${PHPCS_PATH} && $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
-    sed -i.bak s={phpcs_path}=${PHPCS_PATH}=g ${PROJECT}/.git/hooks/pre-commit
+    sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
     sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}=g ${PROJECT}/.git/hooks/pre-commit
   else
     sed -i.bak s={phpcs_path}=${PROJECT}/vendor/bin/phpcs=g ${PROJECT}/.git/hooks/pre-commit

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -7,7 +7,7 @@ readonly BIN="$(cd "$(dirname "$0")" && pwd -P)"
 readonly DIR="$BIN/$(dirname "$(readlink "$0")")"
 readonly PROJECT="$(git rev-parse --show-toplevel)"
 readonly PHPCS_PATH=$1
-readonly PHPCS_STANDARD=${2-" "}
+readonly PHPCS_STANDARD=${2:-non-standard}
 readonly ROOT="${PROJECT}/${PHPCS_PATH}"
 
 vip=false

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -23,11 +23,12 @@ error() {
 }
 
 update_root_path() {
-  if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe ${PHPCS_STANDARD} | wc -w) ]]; then
+  if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe "${PHPCS_STANDARD}" | wc -w) ]]; then
     sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
     sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}=g ${PROJECT}/.git/hooks/pre-commit
   elif [[ "global" -eq ${PHPCS_PATH} ]]; then
     sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
+    sed -i.bak s={phpcs_standard}=" "=g ${PROJECT}/.git/hooks/pre-commit
   else
     sed -i.bak s={phpcs_path}=${PROJECT}/vendor/bin/phpcs=g ${PROJECT}/.git/hooks/pre-commit
   fi

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -21,7 +21,7 @@ error() {
 }
 
 update_root_path() {
-  sed -i.bak s={root}="$ROOT"=g "$DIR"/hooks/pre-commit
+  sed -i.bak s={root}=${ROOT}=g ${DIR}/hooks/pre-commit
 }
 
 # Define command-line options here.

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -21,7 +21,7 @@ error() {
 }
 
 update_root_path() {
-  sed -i.bak s={root}=${ROOT}=g ${PROJECT}/.git/hooks/pre-commit
+  sed -i.bak s={root}=${ROOT}/=g ${PROJECT}/.git/hooks/pre-commit
 }
 
 # Define command-line options here.

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -23,7 +23,7 @@ error() {
 }
 
 update_root_path() {
-  if [[ "global" -eq ${PHPCS_PATH} && $(phpcs -i | grep WordPress | head -c1 | wc -c) -ne 0 ]]; then
+  if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe ${PHPCS_STANDARD} | wc -w) ]]; then
     sed -i.bak s={phpcs_path}=phpcs=g ${PROJECT}/.git/hooks/pre-commit
     sed -i.bak s={phpcs_standard}=${PHPCS_STANDARD}=g ${PROJECT}/.git/hooks/pre-commit
   elif [[ "global" -eq ${PHPCS_PATH} ]]; then
@@ -31,6 +31,8 @@ update_root_path() {
   else
     sed -i.bak s={phpcs_path}=${PROJECT}/vendor/bin/phpcs=g ${PROJECT}/.git/hooks/pre-commit
   fi
+
+  sed -i.bak s={project}=${PROJECT}=g ${PROJECT}/.git/hooks/pre-commit
 }
 
 # Define command-line options here.

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -5,7 +5,7 @@
 readonly VERSION="0.5.0"
 readonly BIN="$(cd "$(dirname "$0")" && pwd -P)"
 readonly DIR="$BIN/$(dirname "$(readlink "$0")")"
-readonly PROJECT="$(pwd)"
+readonly PROJECT="$(git rev-parse --show-toplevel)"
 readonly ROOT="$DIR/$1"
 
 vip=false

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -21,7 +21,7 @@ error() {
 }
 
 update_root_path() {
-  sed -i.bak ={root}="$ROOT"=g "$DIR"/hooks/pre-commit
+  sed -i.bak s={root}="$ROOT"=g "$DIR"/hooks/pre-commit
 }
 
 # Define command-line options here.

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -137,7 +137,7 @@ fi
 # Copy the PHP_CodeSniffer standards file if WordPress standard is not available
 #
 if [[ "global" -eq ${PHPCS_PATH} && 0 -lt $(phpcs -i | grep -woe ${PHPCS_STANDARD} | wc -w) ]]; then
-  echo "WordPress standard is installed as global"
+  echo "WordPress standard has been installed as global using ${PHPCS_STANDARD} as standard"
 elif [[ ! -f "$PROJECT"/phpcs.xml && "$ruleset" = false ]]; then
   if [ "$vip" = false ]; then
     sample_file_name="phpcs.xml.sample"
@@ -161,4 +161,6 @@ fi
 
 echo
 echo "WP Enforcer installed successfully!"
+echo "PhpCS path: ${PHPCS_PATH}"
+echo "Standard: ${PHPCS_STANDARD}"
 exit 0

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -6,7 +6,7 @@ readonly VERSION="0.5.0"
 readonly BIN="$(cd "$(dirname "$0")" && pwd -P)"
 readonly DIR="$BIN/$(dirname "$(readlink "$0")")"
 readonly PROJECT="$(git rev-parse --show-toplevel)"
-readonly ROOT="$DIR/$1"
+readonly ROOT="${PROJECT}/$1"
 
 vip=false
 ruleset=false

--- a/bin/wp-enforcer
+++ b/bin/wp-enforcer
@@ -21,7 +21,7 @@ error() {
 }
 
 update_root_path() {
-  sed -i.bak /{root}/"$ROOT"/g "$DIR"/hooks/pre-commit
+  sed -i.bak ={root}="$ROOT"=g "$DIR"/hooks/pre-commit
 }
 
 # Define command-line options here.


### PR DESCRIPTION
Some times we have our vendor folder in a bellow level where the .git folder is. With this case we can't call ./vendor/bin/phpcs

We could have it in ./web/vendor/bin/phpcs

With this patch you can do it.